### PR TITLE
Add data volumes for case-executor and workflow-editor

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,8 @@ services:
     image: mongo:3.0.2
     networks:
       - workflow-editor
+    volumes:
+      - workflow-editor-data:/data/db
 
   case-executor-service:
     build:
@@ -58,6 +60,8 @@ services:
     image: mongo:3.0.2
     networks:
       - case-executor
+    volumes:
+      - case-executor-data:/data/db
 
   forms-editor-service:
     build: ../forms-editor-service
@@ -75,3 +79,6 @@ networks:
   frontend:
   workflow-editor:
   case-executor:
+volumes:
+  workflow-editor-data:
+  case-executor-data:


### PR DESCRIPTION
Added volumes to the existing mongodb services to persist data across deployments of the image.

Volume documentation: https://docs.docker.com/compose/compose-file/#volume-configuration-reference